### PR TITLE
Fix systemd generator script

### DIFF
--- a/systemd/snapshot-remount-fs
+++ b/systemd/snapshot-remount-fs
@@ -96,7 +96,7 @@ def _enable_remount_fs():
     """
     local_fs_target_dir = join(early_dir, LOCAL_FS_TARGET)
     local_fs_target_path = join(local_fs_target_dir, REMOUNT_FS_UNIT)
-    remount_fs_unit_path = join(SYSTEM_UNIT_DIR, LOCAL_FS_TARGET)
+    remount_fs_unit_path = join(SYSTEM_UNIT_DIR, REMOUNT_FS_UNIT)
     _log_debug(f"Enabling {REMOUNT_FS_UNIT} in {local_fs_target_dir}")
     try:
         makedirs(local_fs_target_dir)

--- a/systemd/snapshot-remount-fs
+++ b/systemd/snapshot-remount-fs
@@ -56,7 +56,7 @@ def _arg_in_cmdline(cmdline, arg):
     """
     for word in cmdline.split():
         if "=" in word and "=" not in arg:
-            (word, _) = word.split("=")
+            (word, _) = word.split("=", maxsplit=1)
         if arg == word:
             return True
     return False


### PR DESCRIPTION
The script was incorrectly splitting kernel command line arguments that contained more than a single '=' character and used the wrong path for the `systemd-remount-fs.service` unit.

Fixes #25.