### PR TITLE
Revert "boom.cache: ignore foreign boot entries when reference counting"

### DIFF
--- a/boom/cache.py
+++ b/boom/cache.py
@@ -564,10 +564,7 @@ class CacheEntry(object):
         """Return the current number of boot entries that reference
         this cache entry.
         """
-        entries = find_entries(Selection(path=self.path))
-        # Ignore foreign boot entries
-        entries = [entry for entry in entries if not entry.read_only]
-        return len(entries)
+        return len(find_entries(Selection(path=self.path)))
 
     #: The list of cached images for this CacheEntry sorted by increasing age
     images = []


### PR DESCRIPTION
This reverts commit f9704eea7b973863ea5a2bf6ad13cd37abce64f6.

The reason for ignoring foreign boot entries when determining reference counts no longer exists (a spurious warning when creating entries with --backup).

This commit causes problems if a boom-managed boot entry is modified outside of boom's control (e.g. by kdumctl/grubby appending a modified crashkernel argument): since boom sees the entry as foreign the images used by it end up with a reference count of zero and are automatically removed.

Revert the above commit to prevent this behaviour:

```
[root@localhost ~]# boom list -VV --debug=all
DEBUG - reading boom configuration from '/boot/boom/boom.conf'
...
DEBUG - Loading cache entries from '/boot/boom/cache/cacheindex.json'
DEBUG - Loaded 2 cache paths and 2 images
DEBUG - Finding cache entries for Selection()
DEBUG - Found 2 cached paths
DEBUG - Finding entries for Selection(path='/initramfs-4.18.0-513.24.1.el8_9.x86_64.img.boom0')
DEBUG - Found 1 entries
DEBUG - Finding entries for Selection(path='/initramfs-4.18.0-513.24.1.el8_9.x86_64.img.boom0')
DEBUG - Found 1 entries
DEBUG - Finding entries for Selection(path='/vmlinuz-4.18.0-513.24.1.el8_9.x86_64.boom0')
DEBUG - Found 1 entries
DEBUG - Finding entries for Selection(path='/vmlinuz-4.18.0-513.24.1.el8_9.x86_64.boom0')
DEBUG - Found 1 entries
INFO - Removed 2 unused cache entries
[root@localhost ~]# boom show 6e810cc
Boot Entry (boot_id=6e810cc)
  title Root LV snapshot before changes
  machine-id b1609d18cd704009b4e3f4142ec64eba
  version 4.18.0-513.24.1.el8_9.x86_64
  linux /vmlinuz-4.18.0-513.24.1.el8_9.x86_64.boom0
  initrd /initramfs-4.18.0-513.24.1.el8_9.x86_64.img.boom0
  options root=/dev/rhel/root_snapshot_before_changes ro rd.lvm.lv=rhel/root_snapshot_before_changes crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M
```