### PR TITLE
Automatically repair boom entries with mismatched boot_id

### DIFF
--- a/boom/bootloader.py
+++ b/boom/bootloader.py
@@ -60,7 +60,7 @@ ENTRIES_PATH = "loader/entries"
 BOOT_ENTRIES_FORMAT = "%s-%s-%s.conf"
 
 #: A regular expression matching the boom file name format.
-BOOT_ENTRIES_PATTERN = r"(\w*)-(\w{1,7})-([a-zA-Z0-9.\-_]*)"
+BOOT_ENTRIES_PATTERN = r"(\w*)-([0-9a-f]{7,})-.*\.conf"
 
 #: The file mode with which BLS entries should be created.
 BOOT_ENTRY_MODE = 0o644

--- a/boom/bootloader.py
+++ b/boom/bootloader.py
@@ -1541,7 +1541,7 @@ class BootEntry(object):
         else:
             if self.disp_boot_id != match.group(2):
                 _log_info("Entry file name does not match boot_id: %s" % entry_basename)
-                self.read_only = True
+                self.update_entry(force=True)
 
         self._unwritten = False
 
@@ -2458,6 +2458,7 @@ class BootEntry(object):
         # Cache old entry path
         to_unlink = self._last_path
         self.write_entry(force=force, expand=expand)
+        _log_info("Rewrote entry %s as %s", self.disp_boot_id, self._entry_path)
         if self._entry_path != to_unlink:
             try:
                 unlink(to_unlink)


### PR DESCRIPTION
External modifications to boom managed boot entries cause a mismatch between the entry `boot_id` and the on-disk filename (which includes the `boot_id` in order to ensure uniqueness):

```
INFO - Entry file name does not match boot_id: 6db8de82fe42457a93cb9fab744d2e99-5f9e916-4.18.0-513.24.1.el8_9.x86_64.conf
```

This can happen for e.g. when tools like grubby are used to make changes to all boot entries, such as updating the `crashkernel` parameter via `kdumctl`:

```
[root@localhost ~]# boom list
BootID  Version                      Name                     RootDevice                            
9fe9d18 4.18.0-513.5.1.el8_9.x86_64  Red Hat Enterprise Linux /dev/mapper/rhel-root                 
7275070 4.18.0-513.24.1.el8_9.x86_64 Red Hat Enterprise Linux /dev/mapper/rhel-root                 
8ae3e64 4.18.0-513.24.1.el8_9.x86_64 Red Hat Enterprise Linux /dev/rhel/root_snapshot_before_changes
```

```
[root@localhost ~]# boom list 8ae3e64 -obootid,options,entryfile
BootID  Options                                                                                                                                 EntryFile                                                                 
8ae3e64 root=/dev/rhel/root_snapshot_before_changes ro rd.lvm.lv=rhel/root_snapshot_before_changes crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M 6db8de82fe42457a93cb9fab744d2e99-5f9e916-4.18.0-513.24.1.el8_9.x86_64.conf
```

Cope with this by re-writing the entry file to the correct `boot_id` when loading entries: if the entry path matches `BOOT_ENTRIES_PATTERN` but the `boot_id` is wrong, call `BootEntry.update_entry()` to rewrite the BLS file:

```
[root@localhost boom]# cat /boot/loader/entries/b1609d18cd704009b4e3f4142ec64eba-8612c29-4.18.0-513.24.1.el8_9.x86_64.conf 
#OsIdentifier: 43747d3888b663d2bc88efd35d0813159a84d291
title Root LV snapshot before changes
machine-id b1609d18cd704009b4e3f4142ec64eba
version 4.18.0-513.24.1.el8_9.x86_64
linux /vmlinuz-4.18.0-513.24.1.el8_9.x86_64.boom0
initrd /initramfs-4.18.0-513.24.1.el8_9.x86_64.img.boom0
options root=/dev/rhel/root_snapshot_before_changes ro rd.lvm.lv=rhel/root_snapshot_before_changes

[root@localhost boom]# boom list
BootID  Version                      Name                     RootDevice                            
1e1a9b4 4.18.0-513.5.1.el8_9.x86_64  Red Hat Enterprise Linux /dev/mapper/rhel-root                 
4ea37b9 4.18.0-513.24.1.el8_9.x86_64 Red Hat Enterprise Linux /dev/mapper/rhel-root                 
e22dd61 5.14.0-362.24.1.el9_3.x86_64 Red Hat Enterprise Linux /dev/mapper/rhel-root                 
8612c29 4.18.0-513.24.1.el8_9.x86_64 Red Hat Enterprise Linux /dev/rhel/root_snapshot_before_changes
6e810cc 4.18.0-513.24.1.el8_9.x86_64 Red Hat Enterprise Linux /dev/rhel/root_snapshot_before_changes

[root@localhost boom]# cat /boot/loader/entries/b1609d18cd704009b4e3f4142ec64eba-6e810cc-4.18.0-513.24.1.el8_9.x86_64.conf 
#OsIdentifier: 43747d3888b663d2bc88efd35d0813159a84d291
title Root LV snapshot before changes
machine-id b1609d18cd704009b4e3f4142ec64eba
version 4.18.0-513.24.1.el8_9.x86_64
linux /vmlinuz-4.18.0-513.24.1.el8_9.x86_64.boom0
initrd /initramfs-4.18.0-513.24.1.el8_9.x86_64.img.boom0
options root=/dev/rhel/root_snapshot_before_changes ro rd.lvm.lv=rhel/root_snapshot_before_changes crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M

DEBUG - Loading BootEntry from 'b1609d18cd704009b4e3f4142ec64eba-8612c29-4.18.0-513.24.1.el8_9.x86_64.conf'
INFO - Entry file name does not match boot_id: b1609d18cd704009b4e3f4142ec64eba-8612c29-4.18.0-513.24.1.el8_9.x86_64.conf
INFO - Rewrote entry 6e810cc as /boot/loader/entries/b1609d18cd704009b4e3f4142ec64eba-6e810cc-4.18.0-513.24.1.el8_9.x86_64.conf
```