### PR TITLE
dist: require python3-dbus

### DIFF
--- a/boom-boot.spec
+++ b/boom-boot.spec
@@ -24,6 +24,7 @@ BuildRequires: systemd-rpm-macros
 
 Requires: python3-boom = %{version}-%{release}
 Requires: %{name}-conf = %{version}-%{release}
+Requires: python3-dbus
 Requires: systemd >= 254
 
 Obsoletes: boom-boot-grub2 <= 1.3


### PR DESCRIPTION
Require the `python3-dbus` package in RPM builds.