### PR TITLE
boom: set file permissions before rename, narrow exception handlers, minor typos

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Fedora deps
         run: >
-          dnf -y install
+          dnf -y install --skip-unavailable
           python3-dbus
           python3-pycodestyle
           python3-sphinx

--- a/boom/__init__.py
+++ b/boom/__init__.py
@@ -28,4 +28,4 @@ from ._boom import *
 from ._boom import __all__
 
 __version__ = "1.6.8"
-# vimself.: set et ts=4 sw=4 :
+# vim: set et ts=4 sw=4 :

--- a/boom/_boom.py
+++ b/boom/_boom.py
@@ -1050,7 +1050,7 @@ def load_profiles_for_class(
         pf_path = path_join(profiles_path, pf)
         try:
             profile_class(profile_file=pf_path)
-        except Exception as err:
+        except (OSError, IOError, ValueError, LookupError) as err:
             _log_warn(
                 "Failed to load %s from '%s': %s", profile_class.__name__, pf_path, err
             )

--- a/boom/bootloader.py
+++ b/boom/bootloader.py
@@ -2484,8 +2484,8 @@ class BootEntry:
         finally:
             close(tmp_fd)
         try:
+            chmod(tmp_path, BOOT_ENTRY_MODE)
             rename(tmp_path, entry_path)
-            chmod(entry_path, BOOT_ENTRY_MODE)
             dir_fd = os_open(boom_entries_path(), O_RDONLY | O_DIRECTORY | O_CLOEXEC)
             try:
                 fsync(dir_fd)

--- a/boom/cache.py
+++ b/boom/cache.py
@@ -590,7 +590,7 @@ def _cache_path(img_path: str, update: bool = True, backup: bool = False) -> Cac
     path_mode = st[ST_MODE]
     path_uid = st[ST_UID]
     path_gid = st[ST_GID]
-    path_attrs: Dict[None, None] = {}  # FIXME xattr support
+    path_attrs: Dict[str, Any] = {}  # FIXME xattr support
 
     # Physically cache the image
     _insert_copy(boot_path, cache_file)

--- a/boom/hostprofile.py
+++ b/boom/hostprofile.py
@@ -255,7 +255,7 @@ def write_host_profiles(force=False):
     for hp in _host_profiles:
         try:
             hp.write_profile(force)
-        except Exception as e:
+        except (OSError, IOError, ValueError, LookupError) as e:
             _log_warn(
                 "Failed to write HostProfile(machine_id='%s'): %s",
                 hp.disp_machine_id,

--- a/boom/osprofile.py
+++ b/boom/osprofile.py
@@ -1280,8 +1280,8 @@ class BoomProfile:
                 f.flush()
                 fdatasync(f.fileno())
         try:
+            chmod(tmp_path, mode)
             rename(tmp_path, profile_path)
-            chmod(profile_path, mode)
             dir_fd = os_open(profile_dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
             try:
                 fsync(dir_fd)


### PR DESCRIPTION
**Security fixes:**
- Set file permissions before rename operations to prevent windows where files
  exist with incorrect permissions (0600). This affects boot entry and profile
  writing in bootloader.py and osprofile.py.

**Code  improvements:**
- Narrow exception handlers from `except Exception` to specific
  types (OSError, IOError, ValueError, LookupError) to avoid masking
  programming errors and improve debugging.
- Fix vim modeline typo (vimself. -> vim:)
- Fix type annotation for path_attrs (Dict[None, None] -> Dict[str, Any])

**CI improvements:**
- Add --skip-unavailable flag to dnf install for cross-version Fedora
  compatibility (handles python3-toml availability in Fedora 42/43 vs 44+)

Resolves: #323, #357, #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of boot entry and profile file creation through refined file permission handling.

* **Chores**
  * Enhanced error handling for profile loading and host profile creation with more targeted exception catching.
  * Optimised GitHub Actions workflow for Fedora dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->