### PR TITLE
stratis: fix D-Bus GetManagedObjects() call signature

### DIFF
--- a/boom/stratis.py
+++ b/boom/stratis.py
@@ -69,7 +69,7 @@ def pool_name_to_pool_uuid(pool_name: str) -> str:  # pragma: no cover
     )
     proxy = bus.get_object(_STRATISD_SERVICE, _STRATISD_PATH, introspect=False)
     object_manager = dbus.Interface(proxy, _DBUS_OBJECT_MANAGER_IFACE)
-    managed_objects = object_manager.GetManagedObjects(_STRATISD_TIMEOUT)
+    managed_objects = object_manager.GetManagedObjects(timeout=_STRATISD_TIMEOUT)
     try:
         props = next(
             obj_data[_POOL_IFACE]


### PR DESCRIPTION
Pass timeout parameter as keyword argument to GetManagedObjects(). The timeout value should be passed as timeout=_STRATISD_TIMEOUT rather than as a positional argument.

Fixes: #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when communicating with the storage service by using the configured timeout correctly for object lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->