### PR TITLE
mounts: simplify boom.mounts._unescape() and add explicit tests

### DIFF
--- a/boom/mounts.py
+++ b/boom/mounts.py
@@ -90,23 +90,15 @@ def _detect_fstype(dev):
 
 def _unescape(escaped: str) -> str:
     """
-    Unescape hex escapes in mount string values.
+    Unescape ":" character in mount string values.
 
     :param escaped: The string to unescape.
     :type escaped: str
-    :returns: The unescaped string with hex escape values replaced by
-              literal character values.
+    :returns: The unescaped string with hex escape value 0x3a replaced by
+              literal colon characters.
     :rtype: str
     """
-    return (
-        escaped.replace("\\x20", " ")
-        .replace("\\x09", "\t")
-        .replace("\\x9", "\t")
-        .replace("\\x0a", "\n")
-        .replace("\\xa", "\n")
-        .replace("\\x3a", ":")
-        .replace("\\x5c", "\\")
-    )
+    return escaped.replace("\\x3a", ":")
 
 
 def _parse_mount_unit(mount):

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -89,6 +89,29 @@ class MountsHelperTests(unittest.TestCase):
                 with self.assertRaises(BoomMountError):
                     parse_mount_units([mount])
 
+    def test__unescape_colon(self):
+        unescaped = boom.mounts._unescape(r"foo\x3abar")
+        self.assertEqual(unescaped, "foo:bar")
+
+    def test__unescape_colon_multiple(self):
+        unescaped = boom.mounts._unescape(r"foo\x3abar\x3abaz\x3aquux")
+        self.assertEqual(unescaped, "foo:bar:baz:quux")
+
+    def test__unescape_other(self):
+        unescaped = boom.mounts._unescape(r"foo\x0abar")
+        self.assertEqual(unescaped, r"foo\x0abar")
+
+    def test__unescape_other_null(self):
+        unescaped = boom.mounts._unescape(r"foo\x00bar")
+        self.assertEqual(unescaped, r"foo\x00bar")
+
+    def test__unescape_bad_str_raises(self):
+        with self.assertRaises(AttributeError):
+            boom.mounts._unescape(None)
+
+        with self.assertRaises(AttributeError):
+            boom.mounts._unescape(0)
+
     def test_parse_swap_units(self):
         swap_list = ["/dev/test/var:defaults", "/dev/sda5:pri=1"]
         xswap_str = ["systemd.swap-extra=/dev/test/var:defaults",


### PR DESCRIPTION
Limit _unescape() to handle only the 0x3a (":") escape that we care about: pass other escapes directly to systemd.mount-extra.

Additionally add some simple explicit unit tests for the function (previously it was only tested indirectly via other tests that implicitly call _unescape()).

Resolves: #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mount unit parsing by limiting escape decoding to colons.
  * Preserved other escaped characters, such as spaces, tabs, newlines, and backslashes, during validation.

* **Tests**
  * Added coverage for colon decoding, preservation of other escape sequences, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->